### PR TITLE
feat(todo_item): add TodoItem model

### DIFF
--- a/app/models/todo_item.rb
+++ b/app/models/todo_item.rb
@@ -1,0 +1,2 @@
+class TodoItem < ApplicationRecord
+end

--- a/db/migrate/20220626225814_create_todo_items.rb
+++ b/db/migrate/20220626225814_create_todo_items.rb
@@ -1,0 +1,10 @@
+class CreateTodoItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :todo_items do |t|
+      t.string :title
+      t.boolean :completed
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,5 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 0) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_26_225814) do
+  create_table "todo_items", force: :cascade do |t|
+    t.string "title"
+    t.boolean "completed"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
 end

--- a/spec/models/todo_item_spec.rb
+++ b/spec/models/todo_item_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe TodoItem, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Creates the TodoItem repository. The model layer will be used as the repository, focusing only on
persistance and retrieval of entities.

closes #2